### PR TITLE
Add soft_delete optional attribute for link_to_remove_fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,21 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.16] - 2021-09-10
+
+- Updated `link_to_remove_fields` method to optionally receive soft_delete attribute.
+
 ## [0.3.15] - 2021-08-29
 
 - Add `transparency funcionality` to navbar.
+
 ## [0.3.14] - 2021-08-29
 
 - Add `facebook, instagram, pinterest, linkedin, mail, phone, map_marker_alt` icons.
+
 ## [0.3.13] - 2021-08-29
 
 - Add `manual closing` to notifications
+
 ## [0.3.12] - 2021-08-29
 
 - Add times icon
+
 ## [0.3.11] - 2021-08-29
 
 - Add notification (alert, success, notification) icons
+
 ## [0.3.10] - 2021-08-29
 
 - Pass options to ransack result method

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    frontend_helpers (0.3.15)
+    frontend_helpers (0.3.16)
       rails (~> 6.1)
       ransack
 

--- a/lib/frontend_helpers/form_builder_helpers/dynamic_fields.rb
+++ b/lib/frontend_helpers/form_builder_helpers/dynamic_fields.rb
@@ -96,8 +96,10 @@ module FrontendHelpers
         html_options['href'] = '#'
         html_options = append_data_action(html_options, 'dynamic-fields#removeFields')
 
+        remove_type = html_options[:soft_delete] ? :_soft_delete : :_destroy
+
         tag.a(name, **html_options) +
-          hidden_field(:_destroy, class: 'destroy-flag')
+          hidden_field(remove_type, class: 'destroy-flag')
       end
 
       private

--- a/lib/frontend_helpers/version.rb
+++ b/lib/frontend_helpers/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FrontendHelpers
-  VERSION = '0.3.15'
+  VERSION = '0.3.16'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-helpers",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "Collection of Stimulus controllers and utilities for building web apps",
   "main": "javascript/src/index.js",
   "module": "javascript/src/index.js",


### PR DESCRIPTION
Updated the `link_to_remove_fields` method from `dynamic_fields`, it can now receive an optional a boolean `soft_delete` attribute to replace the default `destroy` action