### PR TITLE
add optional buttons to date_field helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.21] - 2022-04-12
+
+- Add `buttons previous and next` in date_field helper
+
 ## [0.5.20] - 2022-04-07
 
 - Add `closeOnClick` option to `dropdown-controller` to optionally disable closing it down on click

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    frontend_helpers (0.5.20)
+    frontend_helpers (0.5.21)
       rails (> 6.1)
       ransack
 
@@ -173,7 +173,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.2)
-    sprockets (4.0.3)
+    sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.4.2)

--- a/app/assets/stylesheets/fe_flatpickr_customizations.scss
+++ b/app/assets/stylesheets/fe_flatpickr_customizations.scss
@@ -27,3 +27,10 @@
   background: $link;
   border-color: $link;
 }
+
+.flatpickr {
+  .is-transparent {
+    background-color: transparent;
+    border-color: transparent;
+  }
+}

--- a/cypress/integration/datepicker-controller.spec.js
+++ b/cypress/integration/datepicker-controller.spec.js
@@ -40,4 +40,18 @@ context('DatepickerController', () => {
       .next()
       .should('have.have', 'Tue')
   })
+
+  it('Set next day', () => {
+    cy.get('#date')
+      .as('input')
+      .should('have.value', '2022-03-30')
+
+    cy.get('#previous-btn').click()
+
+    cy.get('@input').should('have.value', '2022-03-29')
+
+    cy.get('#next-btn').click()
+
+    cy.get('@input').should('have.value', '2022-03-30')
+  })
 })

--- a/javascript/docs/datepicker.md
+++ b/javascript/docs/datepicker.md
@@ -115,8 +115,8 @@ description: Datepicker component that uses the flatpicker library
 ### datepicker with buttons to go to the previous or next date
 
 <div class="manual-flatpickr">
-  <div class="field is-horizontal flatpickr" data-controller="datepicker" data-datepicker-alt-input-class-value="form-control input has-text-centered">
-    <button class="button is-transparent" data-action="datepicker#getCustomDate" data-datepicker-date-by-param="day" data-datepicker-add-param="false" id="previous-btn">
+  <div class="field is-horizontal flatpickr" data-controller="datepicker" data-datepicker-period-value="day" data-datepicker-alt-input-class-value="form-control input has-text-centered">
+    <button class="button is-transparent" data-action="datepicker#previousDate" id="previous-btn">
       <span class="icon">
         <svg viewBox="0 0 13 20" class="svg-inline">
           <path d="M12.5098 1.86961L10.7298 0.0996094L0.839844 9.99961L10.7398 19.8996L12.5098 18.1296L4.37984 9.99961L12.5098 1.86961Z" fill="currentColor"></path>
@@ -126,7 +126,7 @@ description: Datepicker component that uses the flatpicker library
     <div class="control is-fullwidth ">
       <input data-action="submit-on-change#submit" value="2022-03-30" manual="date_by day" control_class="is-fullwidth " class="input flatpickr-input" type="hidden" name="date" id="date">
     </div>
-    <button class="button is-transparent" data-action="datepicker#getCustomDate" data-datepicker-date-by-param="day" data-datepicker-add-param="true" id="next-btn">
+    <button class="button is-transparent" data-action="datepicker#nextDate" id="next-btn">
       <span class="icon">
         <svg viewBox="0 0 13 20" class="svg-inline">
           <path d="M0.490234 18.1296L2.26023 19.8996L12.1602 9.99961L2.26023 0.0996094L0.490234 1.86961L8.62023 9.99961L0.490234 18.1296Z" fill="currentColor"></path>

--- a/javascript/docs/datepicker.md
+++ b/javascript/docs/datepicker.md
@@ -111,3 +111,27 @@ description: Datepicker component that uses the flatpicker library
   data-datepicker-locale-value="en"
 />
 ```
+
+### datepicker with buttons to go to the previous or next date
+
+<div class="manual-flatpickr">
+  <div class="field is-horizontal flatpickr" data-controller="datepicker" data-datepicker-alt-input-class-value="form-control input has-text-centered">
+    <button class="button is-transparent" data-action="datepicker#getCustomDate" data-datepicker-date-by-param="day" data-datepicker-add-param="false" id="previous-btn">
+      <span class="icon">
+        <svg viewBox="0 0 13 20" class="svg-inline">
+          <path d="M12.5098 1.86961L10.7298 0.0996094L0.839844 9.99961L10.7398 19.8996L12.5098 18.1296L4.37984 9.99961L12.5098 1.86961Z" fill="currentColor"></path>
+        </svg>
+      </span>
+    </button>
+    <div class="control is-fullwidth ">
+      <input data-action="submit-on-change#submit" value="2022-03-30" manual="date_by day" control_class="is-fullwidth " class="input flatpickr-input" type="hidden" name="date" id="date">
+    </div>
+    <button class="button is-transparent" data-action="datepicker#getCustomDate" data-datepicker-date-by-param="day" data-datepicker-add-param="true" id="next-btn">
+      <span class="icon">
+        <svg viewBox="0 0 13 20" class="svg-inline">
+          <path d="M0.490234 18.1296L2.26023 19.8996L12.1602 9.99961L2.26023 0.0996094L0.490234 1.86961L8.62023 9.99961L0.490234 18.1296Z" fill="currentColor"></path>
+        </svg>
+      </span>
+    </button>
+  </div>
+</div>

--- a/javascript/src/controllers/datepicker-controller.js
+++ b/javascript/src/controllers/datepicker-controller.js
@@ -93,13 +93,13 @@ export class DatepickerController extends Controller {
   }
 
   getPreviousDay () {
-    let currentDate = new Date(this.flatpickr.input.value.replace('-', '/'))
+    const currentDate = new Date(this.flatpickr.input.value.replace('-', '/'))
     currentDate.setDate(currentDate.getDate() - 1)
     this.flatpickr.setDate(currentDate)
   }
 
   getNextDay () {
-    let currentDate = new Date(this.flatpickr.input.value.replace('-', '/'))
+    const currentDate = new Date(this.flatpickr.input.value.replace('-', '/'))
     currentDate.setDate(currentDate.getDate() + 1)
     this.flatpickr.setDate(currentDate)
   }

--- a/javascript/src/controllers/datepicker-controller.js
+++ b/javascript/src/controllers/datepicker-controller.js
@@ -32,6 +32,9 @@ export class DatepickerController extends Controller {
         ? this.element
         : this.element.querySelector('input')
 
+    // this is necesary because `altInputClass` option does not inherit the original classes
+    this.altInputClassValue = `form-control input ${this.altInputClassValue}`
+
     this.flatpickr = flatpickr(input, {
       altInput: true,
       altFormat: this.altFormat(),

--- a/javascript/src/controllers/datepicker-controller.js
+++ b/javascript/src/controllers/datepicker-controller.js
@@ -21,7 +21,8 @@ export class DatepickerController extends Controller {
     minDate: String,
     minTime: String,
     maxTime: String,
-    altInputClass: String
+    altInputClass: String,
+    period: String
   }
 
   async connect () {
@@ -95,30 +96,18 @@ export class DatepickerController extends Controller {
     return format
   }
 
-  getCustomDate ({ params: { dateBy, add } }) {
-    const currentDate = new Date(this.flatpickr.input.value.replace('-', '/'))
+  nextDate () {
+    const currentDate = this.flatpickr.selectedDates[0]
 
-    switch (dateBy) {
+    switch (this.periodValue) {
       case 'day':
-        currentDate.setDate(
-          add
-            ? this.addDates(currentDate.getDate(), 1)
-            : this.subtractDates(currentDate.getDate(), 1)
-        )
+        currentDate.setDate(currentDate.getDate() + 1)
         break
       case 'month':
-        currentDate.setMonth(
-          add
-            ? this.addDates(currentDate.getMonth(), 1)
-            : this.subtractDates(currentDate.getMonth(), 1)
-        )
+        currentDate.setMonth(currentDate.getMonth() + 1)
         break
       case 'year':
-        currentDate.setFullYear(
-          add
-            ? this.addDates(currentDate.getFullYear(), 1)
-            : this.subtractDates(currentDate.getFullYear(), 1)
-        )
+        currentDate.setFullYear(currentDate.getFullYear() + 1)
         break
       default:
         return
@@ -127,11 +116,23 @@ export class DatepickerController extends Controller {
     this.flatpickr.setDate(currentDate)
   }
 
-  addDates (a, b) {
-    return a + b
-  }
+  previousDate () {
+    const currentDate = this.flatpickr.selectedDates[0]
 
-  subtractDates (a, b) {
-    return a - b
+    switch (this.periodValue) {
+      case 'day':
+        currentDate.setDate(currentDate.getDate() - 1)
+        break
+      case 'month':
+        currentDate.setMonth(currentDate.getMonth() - 1)
+        break
+      case 'year':
+        currentDate.setFullYear(currentDate.getFullYear() - 1)
+        break
+      default:
+        return
+    }
+
+    this.flatpickr.setDate(currentDate)
   }
 }

--- a/javascript/src/controllers/datepicker-controller.js
+++ b/javascript/src/controllers/datepicker-controller.js
@@ -91,4 +91,16 @@ export class DatepickerController extends Controller {
 
     return format
   }
+
+  getPreviousDay () {
+    let currentDate = new Date(this.flatpickr.input.value.replace('-', '/'))
+    currentDate.setDate(currentDate.getDate() - 1)
+    this.flatpickr.setDate(currentDate)
+  }
+
+  getNextDay () {
+    let currentDate = new Date(this.flatpickr.input.value.replace('-', '/'))
+    currentDate.setDate(currentDate.getDate() + 1)
+    this.flatpickr.setDate(currentDate)
+  }
 }

--- a/javascript/src/controllers/datepicker-controller.js
+++ b/javascript/src/controllers/datepicker-controller.js
@@ -103,4 +103,28 @@ export class DatepickerController extends Controller {
     currentDate.setDate(currentDate.getDate() + 1)
     this.flatpickr.setDate(currentDate)
   }
+
+  getPreviousMonth () {
+    const currentDate = new Date(this.flatpickr.input.value.replace('-', '/'))
+    currentDate.setMonth(currentDate.getMonth() - 1)
+    this.flatpickr.setDate(currentDate)
+  }
+
+  getNextMonth () {
+    const currentDate = new Date(this.flatpickr.input.value.replace('-', '/'))
+    currentDate.setMonth(currentDate.getMonth() + 1)
+    this.flatpickr.setDate(currentDate)
+  }
+
+  getPreviousYear () {
+    const currentDate = new Date(this.flatpickr.input.value.replace('-', '/'))
+    currentDate.setFullYear(currentDate.getFullYear() - 1)
+    this.flatpickr.setDate(currentDate)
+  }
+
+  getNextYear () {
+    const currentDate = new Date(this.flatpickr.input.value.replace('-', '/'))
+    currentDate.setFullYear(currentDate.getFullYear() + 1)
+    this.flatpickr.setDate(currentDate)
+  }
 }

--- a/javascript/src/controllers/datepicker-controller.js
+++ b/javascript/src/controllers/datepicker-controller.js
@@ -92,39 +92,43 @@ export class DatepickerController extends Controller {
     return format
   }
 
-  getPreviousDay () {
+  getCustomDate ({ params: { dateBy, add } }) {
     const currentDate = new Date(this.flatpickr.input.value.replace('-', '/'))
-    currentDate.setDate(currentDate.getDate() - 1)
+
+    switch (dateBy) {
+      case 'day':
+        currentDate.setDate(
+          add
+            ? this.addDates(currentDate.getDate(), 1)
+            : this.subtractDates(currentDate.getDate(), 1)
+        )
+        break
+      case 'month':
+        currentDate.setMonth(
+          add
+            ? this.addDates(currentDate.getMonth(), 1)
+            : this.subtractDates(currentDate.getMonth(), 1)
+        )
+        break
+      case 'year':
+        currentDate.setFullYear(
+          add
+            ? this.addDates(currentDate.getFullYear(), 1)
+            : this.subtractDates(currentDate.getFullYear(), 1)
+        )
+        break
+      default:
+        return
+    }
+
     this.flatpickr.setDate(currentDate)
   }
 
-  getNextDay () {
-    const currentDate = new Date(this.flatpickr.input.value.replace('-', '/'))
-    currentDate.setDate(currentDate.getDate() + 1)
-    this.flatpickr.setDate(currentDate)
+  addDates (a, b) {
+    return a + b
   }
 
-  getPreviousMonth () {
-    const currentDate = new Date(this.flatpickr.input.value.replace('-', '/'))
-    currentDate.setMonth(currentDate.getMonth() - 1)
-    this.flatpickr.setDate(currentDate)
-  }
-
-  getNextMonth () {
-    const currentDate = new Date(this.flatpickr.input.value.replace('-', '/'))
-    currentDate.setMonth(currentDate.getMonth() + 1)
-    this.flatpickr.setDate(currentDate)
-  }
-
-  getPreviousYear () {
-    const currentDate = new Date(this.flatpickr.input.value.replace('-', '/'))
-    currentDate.setFullYear(currentDate.getFullYear() - 1)
-    this.flatpickr.setDate(currentDate)
-  }
-
-  getNextYear () {
-    const currentDate = new Date(this.flatpickr.input.value.replace('-', '/'))
-    currentDate.setFullYear(currentDate.getFullYear() + 1)
-    this.flatpickr.setDate(currentDate)
+  subtractDates (a, b) {
+    return a - b
   }
 }

--- a/javascript/src/controllers/datepicker-controller.js
+++ b/javascript/src/controllers/datepicker-controller.js
@@ -20,7 +20,8 @@ export class DatepickerController extends Controller {
     defaultDate: String,
     minDate: String,
     minTime: String,
-    maxTime: String
+    maxTime: String,
+    altInputClass: String
   }
 
   async connect () {
@@ -42,7 +43,8 @@ export class DatepickerController extends Controller {
       defaultDate: this.defaultDateValue,
       minDate: this.minDateValue,
       minTime: this.minTimeValue,
-      maxTime: this.maxTimeValue
+      maxTime: this.maxTimeValue,
+      altInputClass: this.altInputClassValue
     })
   }
 

--- a/lib/frontend_helpers/shared_form_builder_utils.rb
+++ b/lib/frontend_helpers/shared_form_builder_utils.rb
@@ -68,7 +68,7 @@ module FrontendHelpers
       end
 
       content_tag(:div, wrapper_options) do
-        input_date_field(previous_btn, next_btn, clear_btn, method, options)
+        input_date_field(clear_btn, method, options)
       end
     end
 

--- a/lib/frontend_helpers/shared_form_builder_utils.rb
+++ b/lib/frontend_helpers/shared_form_builder_utils.rb
@@ -72,11 +72,15 @@ module FrontendHelpers
       end
 
       content_tag(:div, wrapper_options) do
-        if previous_btn.nil?
-          text_field(method, options) + clear_btn
-        else
-          previous_btn + text_field(method, options) + next_btn + clear_btn
-        end
+        input_date_field(previous_btn, next_btn, clear_btn, method, options)
+      end
+    end
+
+    def input_date_field(previous_btn, next_btn, clear_btn, method, options)
+      if previous_btn.nil?
+        text_field(method, options) + clear_btn
+      else
+        previous_btn + text_field(method, options) + next_btn + clear_btn
       end
     end
 

--- a/lib/frontend_helpers/shared_form_builder_utils.rb
+++ b/lib/frontend_helpers/shared_form_builder_utils.rb
@@ -56,10 +56,18 @@ module FrontendHelpers
                     end
                   end
 
+      previous_btn = if options[:manual] # pendiente renombrar esta variable
+                       content_tag(:button, icon_tag('arrow-back'), class: 'button is-transparent')
+                     end
+
+      next_btn = if options.delete(:manual)
+                   content_tag(:button, icon_tag('arrow-forward'), class: 'button is-transparent')
+                 end
+
       options[:control_class] = "is-fullwidth #{options[:control_class]}"
 
       wrapper_options = {
-        class: 'field',
+        class: 'field is-horizontal flatpickr',
         data: { controller: 'datepicker' }
       }.merge!(options.delete(:wrapper_options) || {})
 
@@ -68,7 +76,7 @@ module FrontendHelpers
       end
 
       content_tag(:div, wrapper_options) do
-        text_field(method, options) + clear_btn
+        previous_btn + text_field(method, options) + next_btn + clear_btn
       end
     end
 

--- a/lib/frontend_helpers/shared_form_builder_utils.rb
+++ b/lib/frontend_helpers/shared_form_builder_utils.rb
@@ -57,11 +57,19 @@ module FrontendHelpers
                   end
 
       previous_btn = if options[:manual] # pendiente renombrar esta variable
-                       content_tag(:button, icon_tag('arrow-back'), class: 'button is-transparent')
+                       content_tag(:button, icon_tag('arrow-back'),
+                                   {
+                                     class: 'button is-transparent',
+                                     data: { action: 'datepicker#getPreviousDay' }
+                                   })
                      end
 
       next_btn = if options.delete(:manual)
-                   content_tag(:button, icon_tag('arrow-forward'), class: 'button is-transparent')
+                   content_tag(:button, icon_tag('arrow-forward'),
+                               {
+                                 class: 'button is-transparent',
+                                 data: { action: 'datepicker#getNextDay' }
+                               })
                  end
 
       options[:control_class] = "is-fullwidth #{options[:control_class]}"

--- a/lib/frontend_helpers/shared_form_builder_utils.rb
+++ b/lib/frontend_helpers/shared_form_builder_utils.rb
@@ -60,15 +60,19 @@ module FrontendHelpers
                        content_tag(:button, icon_tag('arrow-back'),
                                    {
                                      class: 'button is-transparent',
-                                     data: { action: 'datepicker#getPreviousDay' }
+                                     data: {
+                                       action: "datepicker#getPrevious#{options[:manual][:date_by].capitalize}"
+                                     }
                                    })
                      end
 
-      next_btn = if options.delete(:manual)
+      next_btn = if options[:manual]
                    content_tag(:button, icon_tag('arrow-forward'),
                                {
                                  class: 'button is-transparent',
-                                 data: { action: 'datepicker#getNextDay' }
+                                 data: {
+                                   action: "datepicker#getNext#{options[:manual][:date_by].capitalize}"
+                                 }
                                })
                  end
 

--- a/lib/frontend_helpers/shared_form_builder_utils.rb
+++ b/lib/frontend_helpers/shared_form_builder_utils.rb
@@ -56,25 +56,9 @@ module FrontendHelpers
                     end
                   end
 
-      previous_btn = if options[:manual] # pendiente renombrar esta variable
-                       content_tag(:button, icon_tag('arrow-back'),
-                                   {
-                                     class: 'button is-transparent',
-                                     data: {
-                                       action: "datepicker#getPrevious#{options[:manual][:date_by].capitalize}"
-                                     }
-                                   })
-                     end
+      previous_btn = (date_field_previous_btn(options) if options[:manual])
 
-      next_btn = if options[:manual]
-                   content_tag(:button, icon_tag('arrow-forward'),
-                               {
-                                 class: 'button is-transparent',
-                                 data: {
-                                   action: "datepicker#getNext#{options[:manual][:date_by].capitalize}"
-                                 }
-                               })
-                 end
+      next_btn = (date_field_next_btn(options) if options[:manual])
 
       options[:control_class] = "is-fullwidth #{options[:control_class]}"
 
@@ -90,6 +74,30 @@ module FrontendHelpers
       content_tag(:div, wrapper_options) do
         previous_btn + text_field(method, options) + next_btn + clear_btn
       end
+    end
+
+    def date_field_previous_btn(options)
+      content_tag(:button, icon_tag('arrow-back'),
+                  {
+                    class: 'button is-transparent',
+                    data: {
+                      action: 'datepicker#getCustomDate',
+                      'datepicker-date-by-param': options[:manual][:date_by],
+                      'datepicker-add-param': false
+                    }
+                  })
+    end
+
+    def date_field_next_btn(options)
+      content_tag(:button, icon_tag('arrow-forward'),
+                  {
+                    class: 'button is-transparent',
+                    data: {
+                      action: 'datepicker#getCustomDate',
+                      'datepicker-date-by-param': options[:manual][:date_by],
+                      'datepicker-add-param': true
+                    }
+                  })
     end
 
     def datetime_field(method, options = {})

--- a/lib/frontend_helpers/shared_form_builder_utils.rb
+++ b/lib/frontend_helpers/shared_form_builder_utils.rb
@@ -56,15 +56,15 @@ module FrontendHelpers
                     end
                   end
 
-      previous_btn = (date_field_previous_btn(options) if options[:manual])
+      previous_btn = date_field_previous_btn if options[:manual]
 
-      next_btn = (date_field_next_btn(options) if options[:manual])
+      next_btn = date_field_next_btn if options[:manual]
 
       options[:control_class] = "is-fullwidth #{options[:control_class]}"
 
       wrapper_options = {
         class: 'field is-horizontal flatpickr',
-        data: { controller: 'datepicker' }
+        data: { controller: 'datepicker', 'datepicker-period-value': options[:period] }
       }.merge!(options.delete(:wrapper_options) || {})
 
       if options[:min_date].present?
@@ -72,31 +72,27 @@ module FrontendHelpers
       end
 
       content_tag(:div, wrapper_options) do
-        previous_btn + text_field(method, options) + next_btn + clear_btn
+        if previous_btn.nil?
+          text_field(method, options) + clear_btn
+        else
+          previous_btn + text_field(method, options) + next_btn + clear_btn
+        end
       end
     end
 
-    def date_field_previous_btn(options)
+    def date_field_previous_btn
       content_tag(:button, icon_tag('arrow-back'),
                   {
                     class: 'button is-transparent',
-                    data: {
-                      action: 'datepicker#getCustomDate',
-                      'datepicker-date-by-param': options[:manual][:date_by],
-                      'datepicker-add-param': false
-                    }
+                    data: { action: 'datepicker#previousDate' }
                   })
     end
 
-    def date_field_next_btn(options)
+    def date_field_next_btn
       content_tag(:button, icon_tag('arrow-forward'),
                   {
                     class: 'button is-transparent',
-                    data: {
-                      action: 'datepicker#getCustomDate',
-                      'datepicker-date-by-param': options[:manual][:date_by],
-                      'datepicker-add-param': true
-                    }
+                    data: { action: 'datepicker#nextDate' }
                   })
     end
 

--- a/lib/frontend_helpers/shared_form_builder_utils.rb
+++ b/lib/frontend_helpers/shared_form_builder_utils.rb
@@ -56,10 +56,6 @@ module FrontendHelpers
                     end
                   end
 
-      previous_btn = date_field_previous_btn if options[:manual]
-
-      next_btn = date_field_next_btn if options[:manual]
-
       options[:control_class] = "is-fullwidth #{options[:control_class]}"
 
       wrapper_options = {
@@ -76,11 +72,11 @@ module FrontendHelpers
       end
     end
 
-    def input_date_field(previous_btn, next_btn, clear_btn, method, options)
-      if previous_btn.nil?
-        text_field(method, options) + clear_btn
+    def input_date_field(clear_btn, method, options)
+      if options[:manual]
+        date_field_previous_btn + text_field(method, options) + date_field_next_btn + clear_btn
       else
-        previous_btn + text_field(method, options) + next_btn + clear_btn
+        text_field(method, options) + clear_btn
       end
     end
 

--- a/lib/frontend_helpers/version.rb
+++ b/lib/frontend_helpers/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FrontendHelpers
-  VERSION = '0.5.20'
+  VERSION = '0.5.21'
 end

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend-helpers",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend-helpers",
-      "version": "0.5.20",
+      "version": "0.5.21",
       "dependencies": {
         "@glidejs/glide": "^3.5",
         "@hotwired/stimulus": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-helpers",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "description": "Collection of Stimulus controllers and utilities for building web apps",
   "main": "javascript/src/index.js",
   "module": "javascript/src/index.js",


### PR DESCRIPTION
Added option to use previous and next buttons, this could be by day, month or year.

<img width="263" alt="Captura de Pantalla 2022-04-12 a la(s) 10 14 32" src="https://user-images.githubusercontent.com/37639003/163017659-9a362859-f549-4b51-b10f-d15b0c15adc3.png">

More details https://github.com/Grupo-AFAL/ga-apps/issues/1134