### PR TITLE
add flex position for date_field in mobile view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.22] - 2022-04-12
+
+- Add `flex position` in date_field input in mobile version
+
 ## [0.5.21] - 2022-04-12
 
 - Add `buttons previous and next` in date_field helper

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    frontend_helpers (0.5.21)
+    frontend_helpers (0.5.22)
       rails (> 6.1)
       ransack
 

--- a/app/assets/stylesheets/fe_flatpickr_customizations.scss
+++ b/app/assets/stylesheets/fe_flatpickr_customizations.scss
@@ -33,4 +33,10 @@
     background-color: transparent;
     border-color: transparent;
   }
+
+  &.is-horizontal {
+    @include mobile {
+      display: flex;
+    }
+  }
 }

--- a/lib/frontend_helpers/version.rb
+++ b/lib/frontend_helpers/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FrontendHelpers
-  VERSION = '0.5.21'
+  VERSION = '0.5.22'
 end

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend-helpers",
-  "version": "0.5.21",
+  "version": "0.5.22",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend-helpers",
-      "version": "0.5.21",
+      "version": "0.5.22",
       "dependencies": {
         "@glidejs/glide": "^3.5",
         "@hotwired/stimulus": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-helpers",
-  "version": "0.5.21",
+  "version": "0.5.22",
   "description": "Collection of Stimulus controllers and utilities for building web apps",
   "main": "javascript/src/index.js",
   "module": "javascript/src/index.js",


### PR DESCRIPTION
Se agregó la posición `flex` para el input en date_field en la versión móvil

Antes: 
<img width="358" alt="Captura de Pantalla 2022-04-12 a la(s) 16 07 47" src="https://user-images.githubusercontent.com/37639003/163068887-99958878-0de0-462e-95bb-7469c067deec.png">

Despues:
<img width="358" alt="Captura de Pantalla 2022-04-12 a la(s) 16 07 04" src="https://user-images.githubusercontent.com/37639003/163068906-d6243338-0391-423e-8fc7-c8a03fbad84c.png">

